### PR TITLE
Fix file permission errors with saved files

### DIFF
--- a/components/configurator/setup.sh
+++ b/components/configurator/setup.sh
@@ -81,6 +81,7 @@ update_permissions() {
   chown 1000:1000 -R /project
   chown 1000:1000 -R /etc/support-extension/socket
   chown 1000:1000 -R /etc/support-extension/public-key
+  chown 1000:1000 -R /etc/support-extension/private-key
 }
 
 setup_directories

--- a/components/interface/Dockerfile
+++ b/components/interface/Dockerfile
@@ -37,4 +37,5 @@ COPY api/src ./src
 COPY --from=client-build /usr/local/app/dist ./public
 
 EXPOSE 3000
+USER 1000
 CMD ["node", "src/index.js"]


### PR DESCRIPTION
The problem was that the interface was running as the root user. This swaps it to use the non-root user.

Resolves #61